### PR TITLE
pass in window explicitly

### DIFF
--- a/lib/javascripts/flamsteed.js
+++ b/lib/javascripts/flamsteed.js
@@ -192,4 +192,4 @@
     define( "flamsteed", [], function () { return window._FS; } );
   }
 
-})(this);
+})(window);


### PR DESCRIPTION
When importing via webpack `this != window`