### PR TITLE
specify properties to send

### DIFF
--- a/lib/javascripts/flamsteed.js
+++ b/lib/javascripts/flamsteed.js
@@ -161,7 +161,35 @@
 
     // PRIVATE
     fs.prototype._processRum = function() {
-      return window.performance.timing;
+      var perfData = {},
+          perfProperties = [
+            "connectEnd",
+            "connectStart",
+            "domComplete",
+            "domContentLoadedEventEnd",
+            "domContentLoadedEventStart",
+            "domInteractive",
+            "domLoading",
+            "domainLookupEnd",
+            "domainLookupStart",
+            "fetchStart",
+            "loadEventEnd",
+            "loadEventStart",
+            "navigationStart",
+            "redirectEnd",
+            "redirectStart",
+            "requestStart",
+            "responseEnd",
+            "responseStart",
+            "secureConnectionStart",
+            "unloadEventEnd",
+            "unloadEventStart" ];
+
+      perfProperties.map(function(el){
+        perfData[el] = window.performance.timing[el];
+      });
+
+      return perfData;
     };
 
     // PRIVATE


### PR DESCRIPTION
specify properties send because window.performance.timing.hasOwnProperty is false for these properties
